### PR TITLE
Int32 -> long for large dbs

### DIFF
--- a/Hashids.net.test/Hashids_test.cs
+++ b/Hashids.net.test/Hashids_test.cs
@@ -92,25 +92,25 @@ namespace HashidsNet.test
 		[Fact]
 		void it_decrypts_an_ecrypted_number()
 		{
-			hashids.Decrypt("ryBo").Should().Equal(new []{ 12345 });
-			hashids.Decrypt("qkpA").Should().Equal(new [] { 1337 });
-			hashids.Decrypt("6aX").Should().Equal(new [] { 808 });
-			hashids.Decrypt("gz9").Should().Equal(new [] { 303 });
+			hashids.Decrypt("ryBo").Should().Equal(new long[]{ 12345 });
+			hashids.Decrypt("qkpA").Should().Equal(new long[] { 1337 });
+			hashids.Decrypt("6aX").Should().Equal(new long[] { 808 });
+			hashids.Decrypt("gz9").Should().Equal(new long[] { 303 });
 		}
 
 		[Fact]
 		void it_decrypts_a_list_of_encrypted_numbers()
 		{
-			hashids.Decrypt("zBphL54nuMyu5").Should().Equal(new[] { 683, 94108, 123, 5 });
-			hashids.Decrypt("kEFy").Should().Equal(new[]{ 1, 2 });
-			hashids.Decrypt("Aztn").Should().Equal(new[]{ 6, 5 });
+			hashids.Decrypt("zBphL54nuMyu5").Should().Equal(new long[] { 683, 94108, 123, 5 });
+			hashids.Decrypt("kEFy").Should().Equal(new long[]{ 1, 2 });
+			hashids.Decrypt("Aztn").Should().Equal(new long[]{ 6, 5 });
 		}
 
 		[Fact]
 		void it_does_not_decrypt_with_a_different_salt()
 		{
 			var peppers = new Hashids("this is my pepper");
-			hashids.Decrypt("ryBo").Should().Equal(new []{ 12345 });
+			hashids.Decrypt("ryBo").Should().Equal(new long[]{ 12345 });
 			peppers.Decrypt("ryBo").Should().Equal(new int [0]);
 		}
 
@@ -118,7 +118,7 @@ namespace HashidsNet.test
 		void it_can_decrypt_from_a_hash_with_a_minimum_length()
 		{
 			var h = new Hashids(salt, 8);
-			h.Decrypt("b9iLXiAa").Should().Equal(new [] {1});
+			h.Decrypt("b9iLXiAa").Should().Equal(new long[] {1});
 		}
 
 		[Fact]

--- a/Hashids.net/Hashids.cs
+++ b/Hashids.net/Hashids.cs
@@ -79,7 +79,7 @@ namespace HashidsNet
 		/// </summary>
 		/// <param name="number">the numbers</param>
 		/// <returns>the hash</returns>
-		public string Encrypt(params int[] numbers)
+		public string Encrypt(params long[] numbers)
 		{
 			return Encode(numbers, Alphabet, Salt, MinHashLength);
 		}
@@ -89,7 +89,7 @@ namespace HashidsNet
 		/// </summary>
 		/// <param name="hash">hash</param>
 		/// <returns>array of numbers.</returns>
-		public int[] Decrypt(string hash)
+		public long[] Decrypt(string hash)
 		{
 			return Decode(hash);
 		}
@@ -102,7 +102,7 @@ namespace HashidsNet
 		/// <param name="salt"></param>
 		/// <param name="minHashLength"></param>
 		/// <returns></returns>
-		private string Encode(int[] numbers, string alphabet, string salt, int minHashLength = 0)
+		private string Encode(long[] numbers, string alphabet, string salt, int minHashLength = 0)
 		{
 			var ret = new StringBuilder();
 
@@ -135,7 +135,7 @@ namespace HashidsNet
 
 			if (ret.Length < minHashLength)
 			{
-				var firstIndex = 0;
+				long firstIndex = 0;
 				for (var i = 0; i < numbers.Length; i++)
 				{
 					firstIndex += (i + 1) * numbers[i];
@@ -156,7 +156,7 @@ namespace HashidsNet
 
 			while (ret.Length < minHashLength)
 			{
-				var padArray = new [] {(int)alphabet[1], (int)alphabet[0]};
+				var padArray = new [] {(long)alphabet[1], (long)alphabet[0]};
 				var padLeft = Encode(padArray, alphabet, salt);
 				var padRight = Encode(padArray, alphabet, string.Join(string.Empty, padArray));
 
@@ -178,13 +178,13 @@ namespace HashidsNet
 			return ret.ToString();
 		}
 
-		private string Hash(int number, string alphabet)
+		private string Hash(long number, string alphabet)
 		{
 			var hash = string.Empty;
 
 			while (number > 0)
 			{
-				hash = string.Concat(alphabet[number % alphabet.Length], hash);
+				hash = string.Concat(alphabet[(int)(number % alphabet.Length)], hash);
 				number = number / alphabet.Length;
 			}
 
@@ -208,9 +208,9 @@ namespace HashidsNet
 		/// </summary>
 		/// <param name="hash"></param>
 		/// <returns></returns>
-		private int[] Decode(string hash)
+		private long[] Decode(string hash)
 		{
-			var ret = new List<int>();
+			var ret = new List<long>();
 			var originalHash = hash;
 			
 			if (!string.IsNullOrEmpty(hash))
@@ -261,7 +261,7 @@ namespace HashidsNet
 			var numbers = ret.ToArray();
 			if (Encrypt(numbers) != originalHash)
 			{
-				return new int[0];
+				return new long[0L];
 			}
 
 			return ret.ToArray();


### PR DESCRIPTION
In large db's, it's common to have id's greater than Int32.MaxValue (especially if you're using HiLo to generate ids). This simple change turns the Int32's into longs.
