### PR TITLE
Fixed overflow when creating hash

### DIFF
--- a/Hashids.net/Hashids.cs
+++ b/Hashids.net/Hashids.cs
@@ -274,7 +274,7 @@ namespace HashidsNet
             for (var i = 0; i < numbers.Length; i++)
                 numbersHashInt += (int)(numbers[i] % (i + 100));
 
-            var lottery = alphabet[(int)numbersHashInt % alphabet.Length];
+            var lottery = alphabet[(int)(numbersHashInt % alphabet.Length)];
             ret.Append(lottery.ToString());
 
             for (var i = 0; i < numbers.Length; i++)


### PR DESCRIPTION
This fixes an overflow when creating the hash for type Int64 (long). The
result is calculated before the cast, to ensure that the resulting
integer isn't negative before the modulo is applied, which can occur
when the value is sufficiently large..

By downcasting the Int64 before the modulo operation, significant
information is lost, the value will likely not result in the expected
index, resulting in an erroneous letter being pulled from the alphabet,
or an IndexOutOfRangeException being thrown due to negative values.