### PR TITLE
alphabet: handle large ratio of alphabet to seps

### DIFF
--- a/src/Hashids.net/Hashids.cs
+++ b/src/Hashids.net/Hashids.cs
@@ -224,9 +224,9 @@ namespace HashidsNet
 
             seps = ConsistentShuffle(seps, salt);
 
-            if (seps.Length == 0 || (alphabet.Length / seps.Length) > SEP_DIV)
+            if (seps.Length == 0 || ((float)alphabet.Length / seps.Length) > SEP_DIV)
             {
-                var sepsLength = (int)Math.Ceiling(alphabet.Length / SEP_DIV);
+                var sepsLength = (int)Math.Ceiling((float)alphabet.Length / SEP_DIV);
                 if (sepsLength == 1)
                     sepsLength = 2;
 

--- a/test/Hashids.net.test/Hashids_test.cs
+++ b/test/Hashids.net.test/Hashids_test.cs
@@ -113,6 +113,13 @@ namespace HashidsNet.test
         }
 
         [Fact]
+        void it_can_encode_with_a_custom_alphabet_and_few_seps()
+        {
+            var h = new Hashids(salt, 0, "ABCDEFGHIJKMNOPQRSTUVWXYZ23456789");
+            h.Encode(1, 2, 3, 4, 5).Should().Be("44HYIRU3TO");
+        }
+
+        [Fact]
         void it_does_not_produce_repeating_patterns_for_identical_numbers()
         {
             hashids.Encode(5, 5, 5, 5).Should().Be("1Wc8cwcE");


### PR DESCRIPTION
When using a custom alphabet, there may be a large ratio of alphabet
characters to separator characters.  When the ratio is larger than 3.5,
the alphabet and separators are adjusted.

However, if we use integer arithmetic, we may not do the adjustment when
the ratio is > 3.5 but < 4.  Use floating point arithmetic to do this
comparison.

Include a test where the ratio of alphabet characters to separator
characters is 3.714.