### PR TITLE
Performance updates

### DIFF
--- a/src/Hashids.net/ArrayExtensions.cs
+++ b/src/Hashids.net/ArrayExtensions.cs
@@ -1,18 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Buffers;
 
 namespace HashidsNet
 {
     public static class ArrayExtensions
     {
-        public static T[] Copy<T>(this T[] array)
-        {
-            return SubArray(array, 0, array.Length);
-        }
-
         public static T[] SubArray<T>(this T[] array, int index)
         {
             return SubArray(array, index, array.Length - index);

--- a/src/Hashids.net/Hashids.cs
+++ b/src/Hashids.net/Hashids.cs
@@ -350,7 +350,7 @@ namespace HashidsNet
             for (var i = 0; i < input.Length; i++)
             {
                 var pos = Array.IndexOf(alphabet, input[i]);
-                number += pos * LongPow(alphabetLength, input.Length - i - 1);
+                number = number * alphabetLength + pos;
             }
 
             return number;
@@ -441,19 +441,6 @@ namespace HashidsNet
                 alphabet[j] = alphabet[i];
                 alphabet[i] = temp;
             }
-        }
-
-        private static long LongPow(int target, int power)
-        {
-            if (power == 0) return 1;
-            long result = target;
-            while (power > 1)
-            {
-                result *= target;
-                power--;
-            }
-
-            return result;
         }
     }
 }

--- a/src/Hashids.net/Hashids.cs
+++ b/src/Hashids.net/Hashids.cs
@@ -141,9 +141,8 @@ namespace HashidsNet
             var numbers = DecodeLong(hash);
 
             foreach (var number in numbers)
-            {
-                builder.Append(string.Format("{0:X}", number).Substring(1));
-            }
+            foreach (var ch in number.ToString("X").AsSpan().Slice(1))
+                builder.Append(ch);
 
             var result = builder.ToString();
             _sbPool.Return(builder);

--- a/src/Hashids.net/Hashids.cs
+++ b/src/Hashids.net/Hashids.cs
@@ -73,115 +73,6 @@ namespace HashidsNet
             SetupGuards();
         }
 
-        /// <summary>
-        /// Encodes the provided numbers into a hashed string.
-        /// </summary>
-        /// <param name="numbers">The numbers to encode.</param>
-        /// <returns>The hashed string.</returns>
-        public virtual string Encode(params int[] numbers)
-        {
-            if (numbers.Any(n => n < 0))
-                return string.Empty;
-
-            return GenerateHashFrom(Array.ConvertAll(numbers, n => (long) n));
-        }
-
-        /// <summary>
-        /// Encodes the provided numbers into a hashed string.
-        /// </summary>
-        /// <param name="numbers">The numbers to encode.</param>
-        /// <returns>The hashed string.</returns>
-        public virtual string Encode(IEnumerable<int> numbers)
-        {
-            return Encode(numbers.ToArray());
-        }
-
-        /// <summary>
-        /// Decodes the provided hash into.
-        /// </summary>
-        /// <param name="hash">The hash.</param>
-        /// <exception cref="T:System.OverflowException">If the decoded number overflows integer.</exception>
-        /// <returns>The numbers.</returns>
-        public virtual int[] Decode(string hash)
-        {
-            var numbers = GetNumbersFrom(hash);
-            return Array.ConvertAll(numbers, n => (int) n);
-        }
-
-        /// <summary>
-        /// Encodes the provided hex string to a hashids hash.
-        /// </summary>
-        /// <param name="hex"></param>
-        /// <returns></returns>
-        public virtual string EncodeHex(string hex)
-        {
-            if (!hexValidator.Value.IsMatch(hex))
-                return string.Empty;
-
-            var matches = hexSplitter.Value.Matches(hex);
-            var numbers = new List<long>(matches.Count);
-
-            foreach (Match match in matches)
-            {
-                var number = Convert.ToInt64(string.Concat("1", match.Value), 16);
-                numbers.Add(number);
-            }
-
-            return EncodeLong(numbers.ToArray());
-        }
-
-        /// <summary>
-        /// Decodes the provided hash into a hex-string.
-        /// </summary>
-        /// <param name="hash"></param>
-        /// <returns></returns>
-        public virtual string DecodeHex(string hash)
-        {
-            var builder = _sbPool.Get();
-            var numbers = DecodeLong(hash);
-
-            foreach (var number in numbers)
-            foreach (var ch in number.ToString("X").AsSpan().Slice(1))
-                builder.Append(ch);
-
-            var result = builder.ToString();
-            _sbPool.Return(builder);
-            return result;
-        }
-
-        /// <summary>
-        /// Decodes the provided hashed string into an array of longs.
-        /// </summary>
-        /// <param name="hash">The hashed string.</param>
-        /// <returns>The numbers.</returns>
-        public long[] DecodeLong(string hash)
-        {
-            return GetNumbersFrom(hash);
-        }
-
-        /// <summary>
-        /// Encodes the provided longs to a hashed string.
-        /// </summary>
-        /// <param name="numbers">The numbers.</param>
-        /// <returns>The hashed string.</returns>
-        public string EncodeLong(params long[] numbers)
-        {
-            if (numbers.Any(n => n < 0))
-                return string.Empty;
-
-            return GenerateHashFrom(numbers);
-        }
-
-        /// <summary>
-        /// Encodes the provided longs to a hashed string.
-        /// </summary>
-        /// <param name="numbers">The numbers.</param>
-        /// <returns>The hashed string.</returns>
-        public string EncodeLong(IEnumerable<long> numbers)
-        {
-            return EncodeLong(numbers.ToArray());
-        }
-
         private void SetupSeps()
         {
             // seps should contain only characters present in alphabet; 
@@ -231,6 +122,115 @@ namespace HashidsNet
                 _guards = _alphabet.SubArray(0, guardCount);
                 _alphabet = _alphabet.SubArray(guardCount);
             }
+        }
+
+        /// <summary>
+        /// Encodes the provided numbers into a hashed string.
+        /// </summary>
+        /// <param name="numbers">The numbers to encode.</param>
+        /// <returns>The hashed string.</returns>
+        public virtual string Encode(params int[] numbers)
+        {
+            if (numbers.Any(n => n < 0))
+                return string.Empty;
+
+            return GenerateHashFrom(Array.ConvertAll(numbers, n => (long) n));
+        }
+
+        /// <summary>
+        /// Encodes the provided numbers into a hashed string.
+        /// </summary>
+        /// <param name="numbers">The numbers to encode.</param>
+        /// <returns>The hashed string.</returns>
+        public virtual string Encode(IEnumerable<int> numbers)
+        {
+            return Encode(numbers.ToArray());
+        }
+
+        /// <summary>
+        /// Decodes the provided hash into.
+        /// </summary>
+        /// <param name="hash">The hash.</param>
+        /// <exception cref="T:System.OverflowException">If the decoded number overflows integer.</exception>
+        /// <returns>The numbers.</returns>
+        public virtual int[] Decode(string hash)
+        {
+            var numbers = GetNumbersFrom(hash);
+            return Array.ConvertAll(numbers, n => (int) n);
+        }
+
+        /// <summary>
+        /// Decodes the provided hashed string into an array of longs.
+        /// </summary>
+        /// <param name="hash">The hashed string.</param>
+        /// <returns>The numbers.</returns>
+        public long[] DecodeLong(string hash)
+        {
+            return GetNumbersFrom(hash);
+        }
+
+        /// <summary>
+        /// Encodes the provided longs to a hashed string.
+        /// </summary>
+        /// <param name="numbers">The numbers.</param>
+        /// <returns>The hashed string.</returns>
+        public string EncodeLong(params long[] numbers)
+        {
+            if (numbers.Any(n => n < 0))
+                return string.Empty;
+
+            return GenerateHashFrom(numbers);
+        }
+
+        /// <summary>
+        /// Encodes the provided longs to a hashed string.
+        /// </summary>
+        /// <param name="numbers">The numbers.</param>
+        /// <returns>The hashed string.</returns>
+        public string EncodeLong(IEnumerable<long> numbers)
+        {
+            return EncodeLong(numbers.ToArray());
+        }
+
+        /// <summary>
+        /// Encodes the provided hex string to a hashids hash.
+        /// </summary>
+        /// <param name="hex"></param>
+        /// <returns></returns>
+        public virtual string EncodeHex(string hex)
+        {
+            if (!hexValidator.Value.IsMatch(hex))
+                return string.Empty;
+
+            var matches = hexSplitter.Value.Matches(hex);
+            var numbers = new List<long>(matches.Count);
+
+            foreach (Match match in matches)
+            {
+                var number = Convert.ToInt64(string.Concat("1", match.Value), 16);
+                numbers.Add(number);
+            }
+
+            return EncodeLong(numbers.ToArray());
+        }
+
+        /// <summary>
+        /// Decodes the provided hash into a hex-string.
+        /// </summary>
+        /// <param name="hash"></param>
+        /// <returns></returns>
+        public virtual string DecodeHex(string hash)
+        {
+            var builder = _sbPool.Get();
+            var numbers = DecodeLong(hash);
+
+            foreach (var number in numbers)
+            foreach (var ch in number.ToString("X").AsSpan().Slice(1))
+                builder.Append(ch);
+
+            var result = builder.ToString();
+            _sbPool.Return(builder);
+            return result;
         }
 
         /// <summary>
@@ -329,14 +329,6 @@ namespace HashidsNet
             return result;
         }
 
-        private char[] CreateBuffer(int alphabetLength, char lottery)
-        {
-            var buffer = System.Buffers.ArrayPool<char>.Shared.Rent(alphabetLength);
-            buffer[0] = lottery;
-            Array.Copy(_salt, 0, buffer, 1, Math.Min(_salt.Length, alphabetLength - 1));
-            return buffer;
-        }
-
         private char[] Hash(long input, char[] alphabet, int alphabetLength)
         {
             var hash = new List<char>(4);
@@ -362,19 +354,6 @@ namespace HashidsNet
             }
 
             return number;
-        }
-
-        private static long LongPow(int target, int power)
-        {
-            if (power == 0) return 1;
-            long result = target;
-            while (power > 1)
-            {
-                result *= target;
-                power--;
-            }
-
-            return result;
         }
 
         private long[] GetNumbersFrom(string hash)
@@ -438,6 +417,14 @@ namespace HashidsNet
             return result.ToArray();
         }
 
+        private char[] CreateBuffer(int alphabetLength, char lottery)
+        {
+            var buffer = System.Buffers.ArrayPool<char>.Shared.Rent(alphabetLength);
+            buffer[0] = lottery;
+            Array.Copy(_salt, 0, buffer, 1, Math.Min(_salt.Length, alphabetLength - 1));
+            return buffer;
+        }
+
         private void ConsistentShuffle(char[] alphabet, int alphabetLength, char[] salt, int saltLength)
         {
             if (salt.Length == 0)
@@ -454,6 +441,19 @@ namespace HashidsNet
                 alphabet[j] = alphabet[i];
                 alphabet[i] = temp;
             }
+        }
+
+        private static long LongPow(int target, int power)
+        {
+            if (power == 0) return 1;
+            long result = target;
+            while (power > 1)
+            {
+                result *= target;
+                power--;
+            }
+
+            return result;
         }
     }
 }

--- a/src/Hashids.net/Hashids.net.csproj
+++ b/src/Hashids.net/Hashids.net.csproj
@@ -18,8 +18,14 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.ObjectPool">
+          <Version>5.0.5</Version>
+        </PackageReference>
         <PackageReference Include="System.Buffers">
             <Version>4.5.1</Version>
+        </PackageReference>
+        <PackageReference Include="System.Memory">
+          <Version>4.5.4</Version>
         </PackageReference>
     </ItemGroup>
 

--- a/src/Hashids.net/IHashids.cs
+++ b/src/Hashids.net/IHashids.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace HashidsNet
 {

--- a/test/Hashids.net.benchmark/Program.cs
+++ b/test/Hashids.net.benchmark/Program.cs
@@ -14,7 +14,9 @@ namespace Hashids.net.benchmark
         public class HashBenchmark
         {
             private readonly HashidsNet.Hashids _hashids;
-            private readonly int[] _input = { 12345, 1234567890, int.MaxValue };
+            private readonly int[] _ints = { 12345, 1234567890, int.MaxValue };
+            private readonly long[] _longs = { 12345, 1234567890123456789, long.MaxValue };
+            private readonly string _hex = "507f1f77bcf86cd799439011";
 
             public HashBenchmark()
             {
@@ -22,10 +24,24 @@ namespace Hashids.net.benchmark
             }
 
             [Benchmark]
-            public void Run()
+            public void RoundtripInts()
             {
-                var encodedValue = _hashids.Encode(_input);
+                var encodedValue = _hashids.Encode(_ints);
                 var decodedValue = _hashids.Decode(encodedValue);
+            }
+
+            [Benchmark]
+            public void RoundtripLongs()
+            {
+                var encodedValue = _hashids.EncodeLong(_longs);
+                var decodedValue = _hashids.DecodeLong(encodedValue);
+            }
+
+            [Benchmark]
+            public void RoundtripHex()
+            {
+                var encodedValue = _hashids.EncodeHex(_hex);
+                var decodedValue = _hashids.DecodeHex(encodedValue);
             }
         }
     }


### PR DESCRIPTION
latest benchmarks, reduced some allocations and improved runtime

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
AMD Ryzen 9 3900X, 1 CPU, 24 logical and 12 physical cores
.NET Core SDK=5.0.202
  [Host]     : .NET Core 5.0.5 (CoreCLR 5.0.521.16609, CoreFX 5.0.521.16609), X64 RyuJIT
  DefaultJob : .NET Core 5.0.5 (CoreCLR 5.0.521.16609, CoreFX 5.0.521.16609), X64 RyuJIT


```
|         Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
|  RoundtripInts | 4.250 μs | 0.0814 μs | 0.1000 μs | 0.2213 |     - |     - |   1.85 KB |
| RoundtripLongs | 4.758 μs | 0.0574 μs | 0.0537 μs | 0.2518 |     - |     - |    2.1 KB |
|   RoundtripHex | 4.388 μs | 0.0196 μs | 0.0184 μs | 0.3815 |     - |     - |   3.16 KB |


|         Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
|  RoundtripInts | 4.301 μs | 0.0545 μs | 0.0510 μs | 0.1755 |     - |     - |   1.45 KB |
| RoundtripLongs | 4.883 μs | 0.0391 μs | 0.0366 μs | 0.2060 |     - |     - |    1.7 KB |
|   RoundtripHex | 4.443 μs | 0.0173 μs | 0.0153 μs | 0.3052 |     - |     - |   2.55 KB |


|         Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
|  RoundtripInts | 4.122 us | 0.0274 us | 0.0257 us | 0.1755 |     - |     - |   1.45 KB |
| RoundtripLongs | 4.699 us | 0.0880 us | 0.0780 us | 0.2060 |     - |     - |    1.7 KB |
|   RoundtripHex | 4.300 us | 0.0607 us | 0.0538 us | 0.2899 |     - |     - |   2.41 KB |


|         Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
|  RoundtripInts | 4.119 us | 0.0102 us | 0.0090 us | 0.1755 |     - |     - |   1.45 KB |
| RoundtripLongs | 4.608 us | 0.0888 us | 0.0912 us | 0.2060 |     - |     - |    1.7 KB |
|   RoundtripHex | 4.314 us | 0.0518 us | 0.0485 us | 0.2899 |     - |     - |   2.41 KB |
