### PR TITLE
Clean up packages and use internal object pool for stringbuilder

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,0 +1,1 @@
+dotnet run --project .\test\Hashids.net.benchmark\Hashids.net.benchmark.csproj -c Release

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+dotnet clean
+dotnet test
+dotnet build -c Release

--- a/src/Hashids.net/Hashids.cs
+++ b/src/Hashids.net/Hashids.cs
@@ -1,9 +1,7 @@
 ﻿using System.Collections.Generic;
 using System;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using Microsoft.Extensions.ObjectPool;
 using System.Buffers;
 
 namespace HashidsNet
@@ -29,7 +27,7 @@ namespace HashidsNet
         private char[] _salt;
         private readonly int _minHashLength;
 
-        private readonly ObjectPool<StringBuilder> _sbPool = new DefaultObjectPool<StringBuilder>(new StringBuilderPooledObjectPolicy());
+        private readonly StringBuilderPool _sbPool = new();
 
         // Creates the Regex in the first usage, speed up first use of non-hex methods
         private static readonly Lazy<Regex> hexValidator = new(() => new Regex("^[0-9a-fA-F]+$", RegexOptions.Compiled));

--- a/src/Hashids.net/Hashids.net.csproj
+++ b/src/Hashids.net/Hashids.net.csproj
@@ -24,7 +24,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="5.0.7" />
       <PackageReference Include="System.Buffers" Version="4.5.1" />
     </ItemGroup>
 

--- a/src/Hashids.net/Hashids.net.csproj
+++ b/src/Hashids.net/Hashids.net.csproj
@@ -24,15 +24,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.ObjectPool">
-            <Version>5.0.5</Version>
-        </PackageReference>
-        <PackageReference Include="System.Buffers">
-            <Version>4.5.1</Version>
-        </PackageReference>
-        <PackageReference Include="System.Memory">
-            <Version>4.5.4</Version>
-        </PackageReference>
+      <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="5.0.7" />
+      <PackageReference Include="System.Buffers" Version="4.5.1" />
     </ItemGroup>
 
 </Project>

--- a/src/Hashids.net/StringBuilderPool.cs
+++ b/src/Hashids.net/StringBuilderPool.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Concurrent;
+using System.Text;
+
+namespace HashidsNet
+{
+    internal class StringBuilderPool
+    {
+        private readonly ConcurrentBag<StringBuilder> _builders = new();
+
+        public StringBuilder Get() => _builders.TryTake(out StringBuilder sb) ? sb : new();
+
+        public void Return(StringBuilder sb)
+        {
+            sb.Clear();
+            _builders.Add(sb);
+        }
+    }
+}


### PR DESCRIPTION
- Cleanup unused nuget references
- Replace `Microsoft.Extensions.ObjectPool` with internal implementation using `ConcurrentBag<>`