### PR TITLE
Added support for .NET6

### DIFF
--- a/src/Hashids.net/Hashids.net.csproj
+++ b/src/Hashids.net/Hashids.net.csproj
@@ -13,7 +13,7 @@
         <PackageTags>ids;hash</PackageTags>
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/ullmark/hashids.net</RepositoryUrl>
-        <TargetFrameworks>net461;net5.0;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net461;netstandard2.0;net5.0;net6.0</TargetFrameworks>
         <OutputType>Library</OutputType>
         <LangVersion>9</LangVersion>
         <IncludeSymbols>true</IncludeSymbols>

--- a/test/Hashids.net.benchmark/HashBenchmarks.cs
+++ b/test/Hashids.net.benchmark/HashBenchmarks.cs
@@ -1,0 +1,61 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+
+namespace Hashids.net.benchmark
+{
+    [MemoryDiagnoser]
+    [MemoryRandomization]
+    [DisassemblyDiagnoser]
+    [SimpleJob(RuntimeMoniker.Net48)]
+    [SimpleJob(RuntimeMoniker.Net50)]
+    [SimpleJob(RuntimeMoniker.Net60)]
+    [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByJob)]
+    public class HashBenchmarks
+    {
+        private readonly HashidsNet.Hashids _hashids;
+        private readonly int[] _ints = { 12345, 1234567890, int.MaxValue };
+        private readonly long[] _longs = { 12345, 1234567890123456789, long.MaxValue };
+        private readonly string _hex = "507f1f77bcf86cd799439011";
+
+        public HashBenchmarks()
+        {
+            _hashids = new HashidsNet.Hashids();
+        }
+
+        [Benchmark]
+        public void RoundtripInts()
+        {
+            var encodedValue = _hashids.Encode(_ints);
+            var decodedValue = _hashids.Decode(encodedValue);
+        }
+
+        [Benchmark]
+        public void RoundtripLongs()
+        {
+            var encodedValue = _hashids.EncodeLong(_longs);
+            var decodedValue = _hashids.DecodeLong(encodedValue);
+        }
+
+        [Benchmark]
+        public void RoundtripHex()
+        {
+            var encodedValue = _hashids.EncodeHex(_hex);
+            var decodedValue = _hashids.DecodeHex(encodedValue);
+        }
+
+        [Benchmark]
+        public void SingleNumber()
+        {
+            var encoded = _hashids.Encode(5);
+            var encodeLong = _hashids.EncodeLong(5);
+        }
+
+        [Benchmark]
+        public void SingleNumberAsParams()
+        {
+            var encoded = _hashids.Encode(new[] { 1 });
+            var encodedLong = _hashids.EncodeLong(new[] { (long)1 });
+        }
+    }
+}

--- a/test/Hashids.net.benchmark/Hashids.net.benchmark.csproj
+++ b/test/Hashids.net.benchmark/Hashids.net.benchmark.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+        <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Hashids.net.benchmark/Program.cs
+++ b/test/Hashids.net.benchmark/Program.cs
@@ -1,5 +1,4 @@
-﻿using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Running;
+﻿using BenchmarkDotNet.Running;
 
 namespace Hashids.net.benchmark
 {
@@ -7,56 +6,7 @@ namespace Hashids.net.benchmark
     {
         public static void Main(string[] args)
         {
-            var summary = BenchmarkRunner.Run<HashBenchmark>();
-        }
-
-        [MemoryDiagnoser]
-        public class HashBenchmark
-        {
-            private readonly HashidsNet.Hashids _hashids;
-            private readonly int[] _ints = { 12345, 1234567890, int.MaxValue };
-            private readonly long[] _longs = { 12345, 1234567890123456789, long.MaxValue };
-            private readonly string _hex = "507f1f77bcf86cd799439011";
-
-            public HashBenchmark()
-            {
-                _hashids = new HashidsNet.Hashids();
-            }
-
-            [Benchmark]
-            public void RoundtripInts()
-            {
-                var encodedValue = _hashids.Encode(_ints);
-                var decodedValue = _hashids.Decode(encodedValue);
-            }
-
-            [Benchmark]
-            public void RoundtripLongs()
-            {
-                var encodedValue = _hashids.EncodeLong(_longs);
-                var decodedValue = _hashids.DecodeLong(encodedValue);
-            }
-
-            [Benchmark]
-            public void RoundtripHex()
-            {
-                var encodedValue = _hashids.EncodeHex(_hex);
-                var decodedValue = _hashids.DecodeHex(encodedValue);
-            }
-
-            [Benchmark]
-            public void SingleNumber()
-            {
-                var encoded = _hashids.Encode(5);
-                var encodeLong = _hashids.EncodeLong(5);
-            }
-
-            [Benchmark]
-            public void SingleNumberAsParams()
-            {
-                var encoded = _hashids.Encode(new []{ 1 });
-                var encodedLong = _hashids.EncodeLong(new []{ (long)1 });
-            }
+            var summary = BenchmarkRunner.Run<HashBenchmarks>();
         }
     }
 }

--- a/test/Hashids.net.test/Hashids.net.test.csproj
+++ b/test/Hashids.net.test/Hashids.net.test.csproj
@@ -2,10 +2,10 @@
 
     <PropertyGroup>
 		<!--
-		The main project targets net461, net5.0, and netstandard2.0.
+		The main project targets net461, netstandard2.0, net5.0 and net6.0
 		As test projects cannot target netstandard the net48 target is used as a stand-in for that.
 		-->
-        <TargetFrameworks>net461;net48;net5.0</TargetFrameworks>
+        <TargetFrameworks>net461;net48;net5.0;net6.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <LangVersion>9</LangVersion>
     </PropertyGroup>


### PR DESCRIPTION
This PR adds net6.0 as a target framework.
Also updated version of BenchmarkDotNet to 0.13.1