### PR TITLE
Replaced explicit throws with ThrowHelper calls

### DIFF
--- a/src/Hashids.net/ArrayExtensions.cs
+++ b/src/Hashids.net/ArrayExtensions.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Buffers;
-using System.Collections.Generic;
-using System.Text.RegularExpressions;
 
 namespace HashidsNet
 {

--- a/src/Hashids.net/Hashids.cs
+++ b/src/Hashids.net/Hashids.cs
@@ -55,13 +55,13 @@ namespace HashidsNet
             string seps = DEFAULT_SEPS)
         {
             if (salt == null)
-                throw new ArgumentNullException(nameof(salt));
+                ThrowHelper.ThrowArgumentNullException(nameof(salt));
             if (string.IsNullOrWhiteSpace(alphabet))
-                throw new ArgumentNullException(nameof(alphabet));
+                ThrowHelper.ThrowArgumentNullException(nameof(alphabet));
             if (minHashLength < 0)
-                throw new ArgumentOutOfRangeException(nameof(minHashLength), "Value must be zero or greater.");
+                ThrowHelper.ThrowArgumentOutOfRangeException(nameof(minHashLength), "Value must be zero or greater.");
             if (string.IsNullOrWhiteSpace(seps))
-                throw new ArgumentNullException(nameof(seps));
+                ThrowHelper.ThrowArgumentNullException(nameof(seps));
 
             _salt = salt.Trim().ToCharArray();
             _minHashLength = minHashLength;
@@ -77,7 +77,7 @@ namespace HashidsNet
 
             if (alphabetChars.Length < MIN_ALPHABET_LENGTH)
             {
-                throw new ArgumentException($"Alphabet must contain at least {MIN_ALPHABET_LENGTH:N0} unique characters.", paramName: nameof(alphabet));
+                ThrowHelper.ThrowArgumentException($"Alphabet must contain at least {MIN_ALPHABET_LENGTH:N0} unique characters.", paramName: nameof(alphabet));
             }
 
             // SetupGuards():
@@ -97,7 +97,7 @@ namespace HashidsNet
             if (alphabetChars.Length < (MIN_ALPHABET_LENGTH - 6))
             {
                 #warning TODO: What should the minimum length be after removing chars in `sep`?
-                throw new ArgumentException($"Alphabet must contain at least {MIN_ALPHABET_LENGTH:N0} unique characters that are also not present in .", paramName: nameof(alphabet));
+                ThrowHelper.ThrowArgumentException($"Alphabet must contain at least {MIN_ALPHABET_LENGTH:N0} unique characters that are also not present in .", paramName: nameof(alphabet));
             }
 
             ConsistentShuffle(alphabet: sepChars, alphabetLength: sepChars.Length, salt: salt, saltLength: salt.Length);

--- a/src/Hashids.net/ReadOnlySpan.cs
+++ b/src/Hashids.net/ReadOnlySpan.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 namespace HashidsNet
 {
 #if !NETCOREAPP3_1_OR_GREATER
-    internal struct ReadOnlySpan<T> : IReadOnlyList<T>
+    internal readonly struct ReadOnlySpan<T> : IReadOnlyList<T>
     {
         public static implicit operator ReadOnlySpan<T>(T[] array)
         {
@@ -39,16 +39,16 @@ namespace HashidsNet
 
             if (this.array.Length == 0)
             {
-                if (startIndex is not (0 or -1)       ) throw new ArgumentOutOfRangeException(paramName: nameof(startIndex), actualValue: startIndex, message: "Value must be zero or -1 for empty arrays.");
-                if (count             != 0            ) throw new ArgumentOutOfRangeException(paramName: nameof(count)     , actualValue: count     , message: "Value must be zero for empty arrays.");
+                if (startIndex is not (0 or -1)       ) ThrowHelper.ThrowArgumentOutOfRangeException(paramName: nameof(startIndex), actualValue: startIndex, message: "Value must be zero or -1 for empty arrays.");
+                if (count             != 0            ) ThrowHelper.ThrowArgumentOutOfRangeException(paramName: nameof(count)     , actualValue: count     , message: "Value must be zero for empty arrays.");
             }
             else
             {
-                if (count              < 0            ) throw new ArgumentOutOfRangeException(paramName: nameof(count)     , actualValue: count     , message: "Value must be non-negative.");
-                if (startIndex         < 0            ) throw new ArgumentOutOfRangeException(paramName: nameof(startIndex), actualValue: startIndex, message: "Value must be non-negative.");
+                if (count              < 0            ) ThrowHelper.ThrowArgumentOutOfRangeException(paramName: nameof(count)     , actualValue: count     , message: "Value must be non-negative.");
+                if (startIndex         < 0            ) ThrowHelper.ThrowArgumentOutOfRangeException(paramName: nameof(startIndex), actualValue: startIndex, message: "Value must be non-negative.");
 
-                if (startIndex         >= array.Length) throw new ArgumentOutOfRangeException(paramName: nameof(startIndex), actualValue: startIndex, message: "Value exceeds the length of the provided array.");
-                if (startIndex + count >  array.Length) throw new ArgumentOutOfRangeException(paramName: nameof(count)     , actualValue: count     , message: "Value (plus " + nameof(startIndex) + ") exceeds the length of the provided array.");
+                if (startIndex         >= array.Length) ThrowHelper.ThrowArgumentOutOfRangeException(paramName: nameof(startIndex), actualValue: startIndex, message: "Value exceeds the length of the provided array.");
+                if (startIndex + count >  array.Length) ThrowHelper.ThrowArgumentOutOfRangeException(paramName: nameof(count)     , actualValue: count     , message: "Value (plus " + nameof(startIndex) + ") exceeds the length of the provided array.");
             }
         }
 
@@ -56,9 +56,10 @@ namespace HashidsNet
         {
             get
             {
-                if(index < 0 || index >= this.count)
+                if (index < 0 || index >= this.count)
                 {
-                    throw new ArgumentOutOfRangeException(paramName: nameof(index), actualValue: index, message: "Value must be between 0 and " + nameof(this.Length) + " (exclusive).");
+                    ThrowHelper.ThrowArgumentOutOfRangeException(paramName: nameof(index), actualValue: index, message: "Value must be between 0 and " + nameof(this.Length) + " (exclusive).");
+                    return default;
                 }
                 else
                 {
@@ -82,14 +83,12 @@ namespace HashidsNet
 
         public IEnumerator<T> GetEnumerator()
         {
-            if( this.count == 0 )
+            if (this.count == 0)
             {
                 return ((IEnumerable<T>)Array.Empty<T>()).GetEnumerator();
             }
-            else
-            {
-                return this.AsEnumerable().GetEnumerator();
-            }
+
+            return this.AsEnumerable().GetEnumerator();
         }
 
         private IEnumerable<T> AsEnumerable()
@@ -103,7 +102,7 @@ namespace HashidsNet
 
         IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
 
-        public ArraySegment<T> AsArraySegment() => new ArraySegment<T>(this.array, offset: this.startIndex, count: this.count);
+        public ArraySegment<T> AsArraySegment() => new (this.array, offset: this.startIndex, count: this.count);
 
         /// <remarks>This method exists because using Linq's extensions over <see cref="IEnumerable{T}"/> or <see cref="IReadOnlyList{T}"/> are a lot slower than doing it directly.</remarks>
         public bool Any(Func<T,bool> predicate)
@@ -111,7 +110,7 @@ namespace HashidsNet
             int endIdx = this.EndIndex;
             for (int i = this.startIndex; i <= endIdx; i++)
             {
-               if(predicate(this.array[i])) return true;
+               if (predicate(this.array[i])) return true;
             }
 
             return false;

--- a/src/Hashids.net/ThrowHelper.cs
+++ b/src/Hashids.net/ThrowHelper.cs
@@ -1,0 +1,42 @@
+﻿using System;
+#if NETCOREAPP3_1_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
+
+namespace HashidsNet
+{
+    internal static class ThrowHelper
+    {
+#if NETCOREAPP3_1_OR_GREATER
+        [DoesNotReturn]
+#endif
+        public static void ThrowArgumentNullException(string paramName)
+        {
+            throw new ArgumentNullException(paramName);
+        }
+
+#if NETCOREAPP3_1_OR_GREATER
+        [DoesNotReturn]
+#endif
+        public static void ThrowArgumentOutOfRangeException(string paramName, string message)
+        {
+            throw new ArgumentOutOfRangeException(paramName, message);
+        }
+
+#if NETCOREAPP3_1_OR_GREATER
+        [DoesNotReturn]
+#endif
+        public static void ThrowArgumentException(string message, string paramName)
+        {
+            throw new ArgumentException(message, paramName);
+        }
+
+#if NETCOREAPP3_1_OR_GREATER
+        [DoesNotReturn]
+#endif
+        public static void ThrowArgumentOutOfRangeException(string paramName, object actualValue, string message)
+        {
+            throw new ArgumentOutOfRangeException(paramName, actualValue, message);
+        }
+    }
+}


### PR DESCRIPTION
Explicitly writing `throw new ...` generates a lot of boilerplate asm code. We can avoid that by using [ThrowHelper](https://docs.microsoft.com/en-us/windows/communitytoolkit/developer-tools/throwhelper) calls.

ASM diffs: https://www.diffchecker.com/yIpy3421

Benchmarks:

Before:
``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.1586 (21H2)
AMD Ryzen 5 3600, 1 CPU, 12 logical and 6 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4470.0), X64 RyuJIT
  Job-HBMDUB : .NET 5.0.15 (5.0.1522.11506), X64 RyuJIT
  Job-JTKHOO : .NET 6.0.3 (6.0.322.12309), X64 RyuJIT
  Job-TSPUWP : .NET Framework 4.8 (4.8.4470.0), X64 RyuJIT

OutlierMode=DontRemove  MemoryRandomization=True  

```
|               Method |           Runtime |     Mean |     Error | Code Size | Allocated |
|--------------------- |------------------- |---------:|----------:|----------:|----------:|
|        RoundtripInts |           .NET 5.0 | 4.615 μs | 0.0239 μs |      50 B |     512 B |
|       RoundtripLongs |          .NET 5.0 | 5.113 μs | 0.0441 μs |   2,900 B |     512 B |
|         RoundtripHex |          .NET 5.0 | 4.641 μs | 0.0895 μs |      50 B |   1,344 B |
|         SingleNumber |         .NET 5.0 | 1.166 μs | 0.0092 μs |     153 B |      64 B |
| SingleNumberAsParams |          .NET 5.0 | 1.167 μs | 0.0072 μs |   1,917 B |     160 B |
|                      |            |         |           |           |           |
|        RoundtripInts |          .NET 6.0 | 4.431 μs | 0.0883 μs |      50 B |     512 B |
|       RoundtripLongs |          .NET 6.0 | 4.921 μs | 0.0238 μs |   2,970 B |     512 B |
|         RoundtripHex |          .NET 6.0 | 4.297 μs | 0.0490 μs |      50 B |   1,344 B |
|         SingleNumber |           .NET 6.0 | 1.115 μs | 0.0064 μs |     145 B |      64 B |
| SingleNumberAsParams |           .NET 6.0 | 1.146 μs | 0.0063 μs |   1,902 B |     160 B |
|                      |            |                    |          |           |           |           |
|        RoundtripInts | .NET Framework 4.8 | 5.405 μs | 0.0406 μs |      51 B |     794 B |
|       RoundtripLongs | .NET Framework 4.8 | 6.218 μs | 0.0643 μs |   4,003 B |     907 B |
|         RoundtripHex | .NET Framework 4.8 | 6.964 μs | 0.1363 μs |      52 B |   1,781 B |
|         SingleNumber | .NET Framework 4.8 | 1.507 μs | 0.0134 μs |   2,950 B |     241 B |
| SingleNumberAsParams | .NET Framework 4.8 | 1.474 μs | 0.0175 μs |   2,950 B |     241 B |

After:
``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.1586 (21H2)
AMD Ryzen 5 3600, 1 CPU, 12 logical and 6 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4470.0), X64 RyuJIT
  Job-HBMDUB : .NET 5.0.15 (5.0.1522.11506), X64 RyuJIT
  Job-JTKHOO : .NET 6.0.3 (6.0.322.12309), X64 RyuJIT
  Job-TSPUWP : .NET Framework 4.8 (4.8.4470.0), X64 RyuJIT

OutlierMode=DontRemove  MemoryRandomization=True  

```
|               Method |            Runtime |     Mean |     Error | Code Size | Allocated |
|--------------------- |------------------- |---------:|----------:|----------:|----------:|
|        RoundtripInts |           .NET 5.0 | 4.675 μs | 0.0702 μs |      50 B |     512 B |
|       RoundtripLongs |           .NET 5.0 | 5.304 μs | 0.1054 μs |   2,900 B |     512 B |
|         RoundtripHex |           .NET 5.0 | 4.665 μs | 0.0599 μs |      50 B |   1,344 B |
|         SingleNumber |           .NET 5.0 | 1.193 μs | 0.0149 μs |     153 B |      64 B |
| SingleNumberAsParams |          .NET 5.0 | 1.204 μs | 0.0135 μs |   1,917 B |     160 B |
|                      |            |           |           |           |           |
|        RoundtripInts |           .NET 6.0 | 4.452 μs | 0.0357 μs |      50 B |     512 B |
|       RoundtripLongs |           .NET 6.0 | 5.011 μs | 0.0955 μs |   2,970 B |     512 B |
|         RoundtripHex |           .NET 6.0 | 4.325 μs | 0.0499 μs |      50 B |   1,344 B |
|         SingleNumber |          .NET 6.0 | 1.147 μs | 0.0217 μs |     145 B |      64 B |
| SingleNumberAsParams |           .NET 6.0 | 1.144 μs | 0.0086 μs |   1,902 B |     160 B |
|                      |            |          |           |           |           |
|        RoundtripInts | .NET Framework 4.8 | 5.432 μs | 0.0579 μs |      51 B |     794 B |
|       RoundtripLongs | .NET Framework 4.8 | 6.312 μs | 0.0419 μs |   3,621 B |     907 B |
|         RoundtripHex | .NET Framework 4.8 | 7.581 μs | 0.1476 μs |      52 B |   1,781 B |
|         SingleNumber | .NET Framework 4.8 | 1.513 μs | 0.0169 μs |   2,568 B |     241 B |
| SingleNumberAsParams | .NET Framework 4.8 | 1.522 μs | 0.0200 μs |   2,568 B |     241 B |