### PR TITLE
Removed System.Buffers dependency for net5.0 and higher

### DIFF
--- a/src/Hashids.net/Hashids.net.csproj
+++ b/src/Hashids.net/Hashids.net.csproj
@@ -23,7 +23,7 @@
         <NoWarn>$(NoWarn);CS1591</NoWarn>
     </PropertyGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netstandard2.0'">
       <PackageReference Include="System.Buffers" Version="4.5.1" />
     </ItemGroup>
 


### PR DESCRIPTION
There is no need to include dependency on System.Buffers for netstandard2.1 and higher as it already comes within the runtime.