### PR TITLE
fix missing frameworks on build

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,14 +18,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [windows-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v2
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
+
+    - name: Setup .NET 5
+      uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: 5.0.x
 
     - name: Install dependencies
       run: dotnet restore


### PR DESCRIPTION
- changed the actions runner os to windows to fix net framework tests
- setup .net 5 separately because for some reason the setup-dotnet 6 does not include .net 5
- bumped the actions checkout and setup dotnet version

builded and tested
[https://github.com/xilapa/hashids.net/actions/runs/2068517715](https://github.com/xilapa/hashids.net/actions/runs/2068517715)