### PR TITLE
Remove `net461` target

### DIFF
--- a/src/Hashids.net/Hashids.net.csproj
+++ b/src/Hashids.net/Hashids.net.csproj
@@ -13,7 +13,7 @@
         <PackageTags>ids;hash</PackageTags>
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/ullmark/hashids.net</RepositoryUrl>
-        <TargetFrameworks>net461;netstandard2.0;net5.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
         <OutputType>Library</OutputType>
         <LangVersion>9</LangVersion>
         <IncludeSymbols>true</IncludeSymbols>
@@ -23,7 +23,7 @@
         <NoWarn>$(NoWarn);CS1591</NoWarn>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'netstandard2.0'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
       <PackageReference Include="System.Buffers" Version="4.5.1" />
     </ItemGroup>
 

--- a/src/Hashids.net/Hashids.net.csproj
+++ b/src/Hashids.net/Hashids.net.csproj
@@ -15,7 +15,7 @@
         <RepositoryUrl>https://github.com/ullmark/hashids.net</RepositoryUrl>
         <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
         <OutputType>Library</OutputType>
-        <LangVersion>9</LangVersion>
+        <LangVersion>latest</LangVersion>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/test/Hashids.net.benchmark/Hashids.net.benchmark.csproj
+++ b/test/Hashids.net.benchmark/Hashids.net.benchmark.csproj
@@ -4,7 +4,7 @@
         <OutputType>Exe</OutputType>
         <TargetFrameworks>net48;net5.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
-        <LangVersion>9</LangVersion>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/Hashids.net.test/Hashids.net.test.csproj
+++ b/test/Hashids.net.test/Hashids.net.test.csproj
@@ -1,13 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-		<!--
-		The main project targets net461, netstandard2.0, net5.0 and net6.0
-		As test projects cannot target netstandard the net48 target is used as a stand-in for that.
-		-->
-        <TargetFrameworks>net461;net48;net5.0;net6.0</TargetFrameworks>
+		<!-- net48 target is used as a stand-in for testing netstandard2.0 -->
+        <TargetFrameworks>net48;net5.0;net6.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
-        <LangVersion>9</LangVersion>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
.NET 4.6.1 is reaching end of life this month. We can drop that target framework and use `netstandard2.0` going forward to cover .NET 4.8.

https://devblogs.microsoft.com/dotnet/net-framework-4-5-2-4-6-4-6-1-will-reach-end-of-support-on-april-26-2022/