### PR TITLE
Refactoring and optimizations

### DIFF
--- a/src/Hashids.net/ArrayExtensions.cs
+++ b/src/Hashids.net/ArrayExtensions.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Buffers;
-using System.Collections.Generic;
-using System.Text.RegularExpressions;
 
 namespace HashidsNet
 {
@@ -33,26 +30,6 @@ namespace HashidsNet
             Array.Copy(array, 0, newArray, 0, array.Length);
             Array.Copy(appendArray, index, newArray, array.Length, length - index);
             return newArray;
-        }
-
-        public static T[] CopyPooled<T>(this T[] array)
-        {
-            return SubArrayPooled(array, 0, array.Length);
-        }
-
-        public static T[] SubArrayPooled<T>(this T[] array, int index, int length)
-        {
-            var subarray = ArrayPool<T>.Shared.Rent(length);
-            Array.Copy(array, index, subarray, 0, length);
-            return subarray;
-        }
-
-        public static void ReturnToPool<T>(this T[] array)
-        {
-            if (array == null)
-                return;
-
-            ArrayPool<T>.Shared.Return(array);
         }
 
 #if NETCOREAPP3_1_OR_GREATER

--- a/src/Hashids.net/Hashids.net.csproj
+++ b/src/Hashids.net/Hashids.net.csproj
@@ -24,11 +24,7 @@
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-      <PackageReference Include="System.Buffers" Version="4.5.1" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <PackageReference Include="System.Memory" Version="4.5.4" />
+	    <PackageReference Include="System.Memory" Version="4.5.4" />
     </ItemGroup>
 
 </Project>

--- a/test/Hashids.net.benchmark/Hashids.net.benchmark.csproj
+++ b/test/Hashids.net.benchmark/Hashids.net.benchmark.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net48;net5.0</TargetFrameworks>
+        <TargetFrameworks>net48;net5.0;net6.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>


### PR DESCRIPTION
In this PR usages of ArrayPool were replaced by stackallocs. In order to avoid StackOverflowException if requested buffer is too large, we will fallback to simple arrays.

Having the same memory allocations we gain 5-20% speed improvements.

Base:
![base](https://user-images.githubusercontent.com/38229504/161381804-bed36ec3-6595-4b2f-8b8b-ee5ddcf7e24a.png)

PR:
![pr](https://user-images.githubusercontent.com/38229504/161381809-fb8ad477-d152-4f71-b11f-f5fe82e71a1a.png)

