### PR TITLE
null or empty string are decoded as empty arrays.

### DIFF
--- a/src/Hashids.net/Hashids.cs
+++ b/src/Hashids.net/Hashids.cs
@@ -565,6 +565,9 @@ namespace HashidsNet
 
         private long[] GetNumbersFrom(string hash)
         {
+            if (string.IsNullOrWhiteSpace(hash))
+                return Array.Empty<long>();
+
             var result = NumbersFrom(hash);
 
             int bufferSizeToAllocate = Math.Max(hash.Length, _minHashLength);
@@ -583,9 +586,6 @@ namespace HashidsNet
 
         private long[] NumbersFrom(string hash)
         {
-            if (string.IsNullOrWhiteSpace(hash))
-                return Array.Empty<long>();
-
             var guardedHash = hash.AsSpan();
             var (count, ranges) = Split(guardedHash, _guards);
 

--- a/test/Hashids.net.test/IssueSpecificTests.cs
+++ b/test/Hashids.net.test/IssueSpecificTests.cs
@@ -95,5 +95,16 @@ namespace HashidsNet.test
 
             Assert.Empty(numbers);
         }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        void Issue93_decoding_null_or_empty_string_should_return_empty_array(string input)
+        {
+            var hashids = new Hashids("salt");
+            int[] numbers = hashids.Decode(input);
+
+            Assert.Empty(numbers);
+        }
     }
 }


### PR DESCRIPTION
Fixes ullmark/hashids.net#93